### PR TITLE
Add vendor-profile for OUI 2736 (dataMatters.io Helium Console)

### DIFF
--- a/2736/vendor-profile.json
+++ b/2736/vendor-profile.json
@@ -1,0 +1,3 @@
+{
+  "name": "dataMatters.io Helium Console"
+}


### PR DESCRIPTION
This PR adds a `vendor-profile.json` under OUI `2736` to ensure our devices display the correct vendor name "dataMatters.io Helium Console" across platforms like datamatters.io and Helium tooling.

For questions please contact m.sajonz@datamatters.io

Thanks!